### PR TITLE
Ignora arquivos e executa quando realizado um push na master

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -6,8 +6,14 @@ name: Workflow CI
 on:
   pull_request:
     branches: [ '*' ]
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
   push:
-    branches: [ '*' ]
+    branches: [ 'master' ]
+    paths-ignore:
+      - '.gitignore'
+      - 'README.md'
 
 jobs:
   tests:


### PR DESCRIPTION
Ignora os arquivos .gitignore e README.md, para não executar em caso de alteração destes arquivos, e executa o workflow em caso de push na branch master